### PR TITLE
Corrected the bounding box on caravel

### DIFF
--- a/mag/caravel.mag
+++ b/mag/caravel.mag
@@ -178,5 +178,5 @@ port 45 nsew signal bidirectional
 flabel metal5 s 161500 400 173500 12400 0 FreeSans 73728 0 0 0 resetb
 port 46 nsew signal input
 << properties >>
-string FIXED_BBOX 0 0 778000 1020000
+string FIXED_BBOX 0 0 776000 1014000
 << end >>

--- a/mag/hexdigits/alpha_0.mag
+++ b/mag/hexdigits/alpha_0.mag
@@ -8,5 +8,5 @@ rect 0 108 108 648
 rect 216 108 324 648
 rect 0 0 324 108
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_1.mag
+++ b/mag/hexdigits/alpha_1.mag
@@ -8,5 +8,5 @@ rect 0 540 216 648
 rect 108 108 216 540
 rect 0 0 324 108
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_2.mag
+++ b/mag/hexdigits/alpha_2.mag
@@ -9,5 +9,5 @@ rect 0 432 324 540
 rect 0 108 108 432
 rect 0 0 324 108
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_3.mag
+++ b/mag/hexdigits/alpha_3.mag
@@ -9,5 +9,5 @@ rect 0 432 324 540
 rect 216 108 324 432
 rect 0 0 324 108
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_4.mag
+++ b/mag/hexdigits/alpha_4.mag
@@ -8,5 +8,5 @@ rect 216 540 324 756
 rect 0 432 324 540
 rect 216 0 324 432
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_5.mag
+++ b/mag/hexdigits/alpha_5.mag
@@ -9,5 +9,5 @@ rect 0 432 324 540
 rect 216 108 324 432
 rect 0 0 324 108
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_6.mag
+++ b/mag/hexdigits/alpha_6.mag
@@ -10,5 +10,5 @@ rect 0 108 108 432
 rect 216 108 324 432
 rect 0 0 324 108
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_7.mag
+++ b/mag/hexdigits/alpha_7.mag
@@ -6,5 +6,5 @@ timestamp 1654634570
 rect 0 648 324 756
 rect 216 0 324 648
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_8.mag
+++ b/mag/hexdigits/alpha_8.mag
@@ -11,5 +11,5 @@ rect 0 108 108 432
 rect 216 108 324 432
 rect 0 0 324 108
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_9.mag
+++ b/mag/hexdigits/alpha_9.mag
@@ -9,5 +9,5 @@ rect 216 540 324 648
 rect 0 432 324 540
 rect 216 0 324 432
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_A.mag
+++ b/mag/hexdigits/alpha_A.mag
@@ -12,5 +12,5 @@ rect 0 216 324 324
 rect 0 0 108 216
 rect 216 0 324 216
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_B.mag
+++ b/mag/hexdigits/alpha_B.mag
@@ -15,5 +15,5 @@ rect 0 72 324 144
 rect 0 36 288 72
 rect 0 0 252 36
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_C.mag
+++ b/mag/hexdigits/alpha_C.mag
@@ -11,5 +11,5 @@ rect 0 72 324 144
 rect 36 36 324 72
 rect 72 0 324 36
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_D.mag
+++ b/mag/hexdigits/alpha_D.mag
@@ -12,5 +12,5 @@ rect 0 72 324 144
 rect 0 36 288 72
 rect 0 0 252 36
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_E.mag
+++ b/mag/hexdigits/alpha_E.mag
@@ -9,5 +9,5 @@ rect 0 324 216 432
 rect 0 108 108 324
 rect 0 0 324 108
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>

--- a/mag/hexdigits/alpha_F.mag
+++ b/mag/hexdigits/alpha_F.mag
@@ -8,5 +8,5 @@ rect 0 432 108 648
 rect 0 324 216 432
 rect 0 0 108 324
 << properties >>
-string FIXED_BBOX 0 -216 432 756
+string FIXED_BBOX 0 0 432 756
 << end >>


### PR DESCRIPTION
Corrected the bounding box on caravel to the newer dimensions of 3880 x 5070 um (previously 3890 x 5100 um).  Reduced the bounding box of the hex digits to not include the font descent, which keeps the hex digit boundary from extending below the chip boundary.

Note that the only change is to the FIXED_BBOX property in the cells mentioned above.  The magic tech file generates a boundary layer around the cell when it generates GDS, which is how the layer dimensions end up where they are in the final layout.