### PR TITLE
Corrected a port assignment in chip_io.mag

### DIFF
--- a/mag/chip_io.mag
+++ b/mag/chip_io.mag
@@ -6005,5 +6005,5 @@ port 113 nsew
 flabel metal2 69924 549360 70200 549436 0 FreeSans 480 180 0 0 mprj_io_drive_sel[61]
 port 123 nsew
 flabel metal2 69924 549502 70200 549578 0 FreeSans 480 180 0 0 mprj_io_drive_sel[60]
-port 125 nsew
+port 458 nsew
 << end >>


### PR DESCRIPTION
Corrected a port assignment in chip_io.mag that prevents correct extraction of the cell in magic, since two ports have the same index, so one of them gets discarded from the subcircuit port list when generating the SPICE netlist.  Otherwise, there should be no consequences of this error.